### PR TITLE
Fix some textures not getting rescaled

### DIFF
--- a/abmatt/brres/brres.py
+++ b/abmatt/brres/brres.py
@@ -367,7 +367,8 @@ class Brres(Clipable, Packable):
                 self.remove_unused_textures(unused)
                 b.resolve()
                 self.mark_modified()
-        for x in self.textures:
+        for name in [tex.name for tex in self.textures]:
+            x = [tex for tex in self.textures if tex.name == name][0]
             x.check()
 
     def remove_unused_textures(self, unused_textures):

--- a/abmatt/brres/brres.py
+++ b/abmatt/brres/brres.py
@@ -367,9 +367,9 @@ class Brres(Clipable, Packable):
                 self.remove_unused_textures(unused)
                 b.resolve()
                 self.mark_modified()
-        for name in [tex.name for tex in self.textures]:
-            x = [tex for tex in self.textures if tex.name == name][0]
-            x.check()
+        all_tex = [x for x in self.textures]
+        for tex in all_tex:
+            tex.check()
 
     def remove_unused_textures(self, unused_textures):
         tex = self.textures


### PR DESCRIPTION
Fixes #43
It happened because it looped over the list of textures, being in this case (with orl being the broken dog picture)
`['smk', 'orl']`
It started with the first element, `smk`, which it rescaled. First it removed the original from the model:
`['orl']`
Then it added back the rescaled one:
`['orl', 'smk']`
But wait - the list has been reordered! So when the loop gets to the second element, it checks `smk` again, sees that it's now fine, and skips `orl` entirely, leaving it broken.
This fixes the issue by using names instead of indexes to loop over it, so it works with a reordered list. This could also be fixed by making the replacement not reorder the list.
I tried to use list comprehensions which I haven't used used before so it might be a bit of a mess, feel free to do it a cleaner way 