### PR TITLE
Brighter colours by default?

### DIFF
--- a/abmatt/brres/mdl0/stage.py
+++ b/abmatt/brres/mdl0/stage.py
@@ -244,7 +244,7 @@ class Stage(Clipable):
         self.bias = BIAS_ZERO
         self.oper = OPER_ADD
         self.clamp = True
-        self.scale = SCALE_NONE
+        self.scale = SCALE_BY_TWO
         self.dest = DEST_OUTPUT
         # alphas
         self.constant_a = CONSTANT_ALPHA_COLOR0_ALPHA


### PR DESCRIPTION
Not sure if this makes sense as the default, but I find that usually multiply by 2 looks better and less washed out, so maybe it could make sense when importing a model? Then again having a brightness multiplier by default might not make sense, I don't know